### PR TITLE
SourceClear: fixes for vulnerable libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,61 +17,61 @@
     <dependency>
       <groupId>org.apache.struts</groupId>
       <artifactId>struts2-core</artifactId>
-      <version>2.5.12</version>
+      <version>2.5.17</version>
     </dependency>
 
     <dependency>
       <groupId>org.mindrot</groupId>
       <artifactId>jbcrypt</artifactId>
-      <version>0.3m</version>
+      <version>0.4</version>
     </dependency>
 
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
-      <version>3.1.1.RELEASE</version>
+      <version>4.3.20.RELEASE</version>
     </dependency>
 
     <dependency>
         <groupId>org.apache.sling</groupId>
         <artifactId>org.apache.sling.engine</artifactId>
-        <version>2.0.4-incubator</version>
+        <version>2.4.6</version>
     </dependency>
 
     <dependency>
       <groupId>org.keycloak</groupId>
       <artifactId>keycloak-saml-core</artifactId>
-      <version>1.8.1.Final</version>
+      <version>2.5.5.Final</version>
     </dependency>
 
     <dependency>
       <groupId>org.neo4j</groupId>
       <artifactId>neo4j-jmx</artifactId>
-      <version>1.3</version>
+      <version>3.0.0-M05</version>
     </dependency>
 
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>1.3.176</version>
+      <version>1.4.198</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka_2.11</artifactId>
-      <version>0.9.0.1</version>
+      <version>0.10.2.2</version>
     </dependency>
 
     <dependency>
       <groupId>net.bull.javamelody</groupId>
       <artifactId>javamelody-core</artifactId>
-      <version>1.59.0</version>
+      <version>1.74.0</version>
     </dependency>
 
     <dependency>
       <groupId>com.orientechnologies</groupId>
       <artifactId>orientdb-server</artifactId>
-      <version>2.1.9</version>
+      <version>2.1.11</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
This pull request was generated by SourceClear to upgrade the following vulnerable libraries:

| Type | Library | From | To | Breaking |
| --- | --- | --- | --- | --- |
| MAVEN | `org.neo4j:neo4j-jmx` | 1.3 | 3.0.0-M05 | No |
| MAVEN | `com.h2database:h2` | 1.3.176 | 1.4.198 | No |
| MAVEN | `org.apache.struts:struts2-core` | 2.5.12 | 2.5.17 | No |
| MAVEN | `net.bull.javamelody:javamelody-core` | 1.59.0 | 1.74.0 | No |
| MAVEN | `com.orientechnologies:orientdb-server` | 2.1.9 | 2.1.11 | No |
| MAVEN | `org.keycloak:keycloak-saml-core` | 1.8.1.Final | 2.5.5.Final | No |
| MAVEN | `org.apache.sling:org.apache.sling.engine` | 2.0.4-incubator | 2.4.6 | No |
| MAVEN | `org.apache.kafka:kafka_2.11` | 0.9.0.1 | 0.10.2.2 | No |

Note that we only upgrade libraries which have versions without any known vulnerabilities. For more information, please see the corresponding [SourceClear report](https://demolabs.sourceclear.io/teams/E77HrK6/scans/7051589).

The **Breaking** column states the likelihood that updating to the recommended library version will cause breaking changes in your code. Please verify that the changes here won't cause issues with your project before merging.

To learn more about this feature, please visit our [Help Center](https://help.veracode.com/reader/hHHR3gv0wYc2WbCclECf_A/root) for documentation.

Note: this pull request was generated because you or someone else with access to this repository granted SourceClear access to submit pull requests.
<!-- srcclr-pr-id-b242cbe65ebca2efb55d36e9972517cc37fe2a45d2e979d061af033f4bb8165f -->
